### PR TITLE
Add Support for text/xml content type

### DIFF
--- a/connexion/content_types.py
+++ b/connexion/content_types.py
@@ -117,6 +117,18 @@ class XMLContentHandler(ContentHandler):
         return data
 
 
+class TextXMLContentHandler(ContentHandler):
+    name = "text/xml"
+    regex = re.compile(r'^text\/xml.*')
+
+    def validate_request(self, request):
+        # Don't validate, leave stream for user to read
+        xml_content = request.body
+        data = xmltodict.parse(xml_content)
+        request.xml = data
+        return data
+
+
 class JSONContentHandler(ContentHandler):
     name = "application/json"
     regex = re.compile(r'^application\/json.*|^.*\+json$')

--- a/connexion/utils.py
+++ b/connexion/utils.py
@@ -10,7 +10,7 @@ def is_xml_mimetype(mimetype):
         maintype, subtype = mimetype.split('/')  # type: str, str
     except (ValueError, AttributeError):
         return False
-    xml = maintype == 'application' and subtype.startswith("xml")
+    xml = (maintype == 'application' or maintype == 'text') and subtype.startswith("xml")
     return xml
 
 


### PR DESCRIPTION
Fixes #  Add support for Content-Type  = 'text/xml'



Changes proposed in this pull request:

 -  Add TextXMLContentHandler Class in content type
 -  Add text type in mimetypes
 
